### PR TITLE
SQL Lite redirect id incorrect fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Please read the [contribution guidelines](contributing.md) or [creating a list g
   - [Oracle](#oracle)
   - [Postgres](#postgres)
   - [SQL](#sql)
-  - [SQL Lite](#sql-lite)
+  - [SQL Lite](#sqlite)
 - [Caching technologies](#caching-technologies)
   - [Memcached](#memcached)
   - [Redis](#redis)


### PR DESCRIPTION
On clicking 'SQL Lite' in Table of content it wasn't redirect to it's section because header of that section is 'SQLite' and not 'SQL Lite'